### PR TITLE
Add codecov to CI

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -12,6 +12,8 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
+    env:
+      OS: ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v3
@@ -31,10 +33,15 @@ jobs:
           # Set up git user for git command to work with tests
           git config --global user.name "tests"
           git config --global user.email "tests@example.com"
-          pytest -vv
+          pytest -v --cov=autobuild --cov-report=xml tests/
 
       - name: Build python package
         run: python -m build
+
+      - name: Upload coverage
+        uses: codecov/codecov-action@v3
+        with:
+          env_vars: OS
 
       - uses: actions/upload-artifact@v3
         with:

--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,9 @@
 *~
 autobuild/version.py
 build/
+coverage.xml
 dist/
+.coverage
 .idea
 .venv
 *.pyc

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Autobuild
 
+[![codecov](https://codecov.io/gh/secondlife/autobuild/branch/main/graph/badge.svg?token=8GBLMAFDIN)](https://codecov.io/gh/secondlife/autobuild)
+
 **Autobuild** is a framework for building packages and for managing the
 dependencies of a package on other packages. It provides a common
 interface to configuring and building any package, but it is not a

--- a/setup.py
+++ b/setup.py
@@ -32,7 +32,7 @@ setuptools.setup(
     ],
     install_requires=['llbase', 'pydot'],
     extras_require={
-        'dev': ['pytest'],
+        'dev': ['pytest', 'pytest-cov'],
         'build': ['build', 'setuptools_scm'],
     },
     python_requires='>=3.7',


### PR DESCRIPTION
Codecov is a popular code coverage reporting platform that offers free analysis for open source repositories. You can see an example of [python-llsd](https://github.com/secondlife/python-llsd)'s report here: https://app.codecov.io/gh/secondlife/python-llsd/tree/main/llsd

Adding this integration will result in coverage reports automatically being reported in new PRs. This behavior can be customized by supplying a `codecov.yaml` file as described at https://docs.codecov.com/docs/common-recipe-list