### PR TITLE
Switch to llsd serialization library

### DIFF
--- a/autobuild/common.py
+++ b/autobuild/common.py
@@ -4,9 +4,6 @@ Low-level autobuild functionality common to all modules.
 Any code that is potentially common to all autobuild sub-commands
 should live in this module. This module should never depend on any
 other autobuild module.
-
-Importing this module will also guarantee that certain dependencies
-are available, such as llbase
 """
 from __future__ import annotations
 

--- a/autobuild/configfile.py
+++ b/autobuild/configfile.py
@@ -8,7 +8,7 @@ import string
 import sys
 from io import StringIO
 
-from llbase import llsd
+import llsd
 
 from autobuild import common
 from autobuild.executable import Executable

--- a/setup.py
+++ b/setup.py
@@ -30,7 +30,7 @@ setuptools.setup(
         'Programming Language :: Python :: 3',
         'Topic :: Software Development :: Libraries :: Python Modules',
     ],
-    install_requires=['llbase', 'pydot'],
+    install_requires=['llsd', 'pydot'],
     extras_require={
         'dev': ['pytest', 'pytest-cov'],
         'build': ['build', 'setuptools_scm'],

--- a/tests/test_edit.py
+++ b/tests/test_edit.py
@@ -1,6 +1,6 @@
 import os
 
-from llbase import llsd
+import llsd
 
 from autobuild import configfile
 from autobuild.autobuild_tool_edit import AutobuildTool


### PR DESCRIPTION
Replace llbase with the new, standalone [llsd](https://github.com/secondlife/python-llsd) library.