### PR TITLE
Add support for downloading packages from private sources

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,8 @@ For more information, see [Autobuild's wiki page][wiki].
 | AUTOBUILD_BUILD_ID | - | Build identifier |
 | AUTOBUILD_CONFIGURATION | - | Target build configuration |
 | AUTOBUILD_CONFIG_FILE | autobuild.xml | Autobuild configuration filename |
+| AUTOBUILD_GITHUB_TOKEN | - | GitHub HTTP authorization token to use during package download |
+| AUTOBUILD_GITLAB_TOKEN | - | GitLab HTTP authorization token to use during package download |
 | AUTOBUILD_INSTALLABLE_CACHE | - | Location of local download cache |
 | AUTOBUILD_LOGLEVEL | WARNING | Log level |
 | AUTOBUILD_PLATFORM | - | Target platform |

--- a/autobuild/autobuild_tool_installables.py
+++ b/autobuild/autobuild_tool_installables.py
@@ -74,7 +74,7 @@ class AutobuildTool(autobuild_base.AutobuildBase):
 
 
 _PACKAGE_ATTRIBUTES = ['description', 'copyright', 'license', 'license_file', 'version']
-_ARCHIVE_ATTRIBUTES = ['hash', 'hash_algorithm', 'url']
+_ARCHIVE_ATTRIBUTES = ['hash', 'hash_algorithm', 'url', 'creds']
 
 
 def _dict_from_key_value_arguments(arguments):
@@ -108,7 +108,8 @@ def _get_new_metadata(config, args_name, args_archive, arguments):
             archive_url = 'file://'+config.absolute_path(archive_path)
         archive_file = get_package_file(args_name, archive_url,
                                         hash_algorithm=key_values.get('hash_algorithm','md5'),
-                                        expected_hash=key_values.get('hash',None))
+                                        expected_hash=key_values.get('hash'),
+                                        creds=key_values.get('creds'))
         if archive_file:
             metadata = get_metadata_from_package(archive_file)
             metadata.archive = configfile.ArchiveDescription()

--- a/autobuild/common.py
+++ b/autobuild/common.py
@@ -25,7 +25,6 @@ from autobuild.version import AUTOBUILD_VERSION_STRING
 
 logger = logging.getLogger(__name__)
 
-
 class AutobuildError(RuntimeError):
     pass
 


### PR DESCRIPTION
This changeset provides support for downloading autobuild packages from restricted sources such as private repositories using GitHub release artifacts or GitLab generic packages.

The way this works is by the addition of an optional parameter: `creds`, which may be specified when adding or editing dependencies:

```
autobuild installables edit my-pkg creds=github url=...
```

This property is used to inform autobuild that it should set a HTTP authorization header specific to the provider (github, gitlab) when downloading the respective artifact. An environment variable containing credentials is expected to be set per-provider in order to keep authorization strategies separate:

```
AUTOBUILD_GITHUB_TOKEN - GitHub Personal Access Token
AUTOBUILD_GITLAB_TOKEN - GitLab Personal Access Token
```

For example, a GitHub actions runner could do the following:
```
export AUTOBUILD_GITHUB_TOKEN=$GITHUB_TOKEN
autobuild install
```

### Future

This functionality could be enhanced to include more providers or authorization schemes. The `autobuild install` command could also be enhanced with equivalent kwargs `--github-token` and `--gitlab-token`.