### PR TITLE
Do not pass Authorization header to redirects

### DIFF
--- a/autobuild/autobuild_tool_install.py
+++ b/autobuild/autobuild_tool_install.py
@@ -193,9 +193,9 @@ def package_cache_path(package):
 
 
 def download_package(package_url: str, timeout=120, creds=None, package_name="") -> http.client.HTTPResponse:
-    headers = {}
-    if creds:
+    req = urllib.request.Request(package_url)
 
+    if creds:
         try:
             token_var = CREDENTIAL_ENVVARS[creds]
         except KeyError:
@@ -203,14 +203,12 @@ def download_package(package_url: str, timeout=120, creds=None, package_name="")
 
         token = os.environ.get(token_var)
         if token:
-            headers["Authorization"] = f"Bearer {token}"
+            req.add_unredirected_header("Authorization", f"Bearer {token}")
         else:
             raise CredentialsNotFoundError(
                 f"Package {package_name} is set to use '{creds}' credentials type but no {token_var} "
                 "environment variable is set"
             )
-
-    req = urllib.request.Request(package_url, headers=headers)
 
     return urllib.request.urlopen(req, data=None, timeout=timeout)
 

--- a/tests/test_install.py
+++ b/tests/test_install.py
@@ -750,6 +750,8 @@ class TestDownloadPackage(unittest.TestCase):
         with envvar("AUTOBUILD_GITHUB_TOKEN", None):
             autobuild_tool_install.download_package("https://example.org/foo.tar.bz2")
             mock_urlopen.assert_called()
+            got_req = mock_urlopen.mock_calls[0].args[0]
+            self.assertIsNone(got_req.unredirected_hdrs.get("Authorization"))
 
     @patch("urllib.request.urlopen")
     def test_download_github(self, mock_urlopen: MagicMock):
@@ -758,7 +760,7 @@ class TestDownloadPackage(unittest.TestCase):
             autobuild_tool_install.download_package("https://example.org/foo.tar.bz2", creds="github")
             mock_urlopen.assert_called()
             got_req = mock_urlopen.mock_calls[0].args[0]
-            self.assertEqual(got_req.headers["Authorization"], "Bearer token-123")
+            self.assertEqual(got_req.unredirected_hdrs["Authorization"], "Bearer token-123")
 
     @patch("urllib.request.urlopen")
     def test_download_gitlab(self, mock_urlopen: MagicMock):
@@ -767,7 +769,7 @@ class TestDownloadPackage(unittest.TestCase):
             autobuild_tool_install.download_package("https://example.org/foo.tar.bz2", creds="gitlab")
             mock_urlopen.assert_called()
             got_req = mock_urlopen.mock_calls[0].args[0]
-            self.assertEqual(got_req.headers["Authorization"], "Bearer token-123")
+            self.assertEqual(got_req.unredirected_hdrs["Authorization"], "Bearer token-123")
 
     @patch("urllib.request.urlopen")
     def test_download_github_without_creds(self, mock_urlopen: MagicMock):


### PR DESCRIPTION
GitHub and GitLab artifact download URLs may redirect to other locations which should not receive the Authorization header.