### PR TITLE
Add SHA1, SHA256 package hashes

### DIFF
--- a/autobuild/autobuild_tool_edit.py
+++ b/autobuild/autobuild_tool_edit.py
@@ -247,7 +247,7 @@ class Archive(InteractiveCommand):
     ARGUMENTS = ['format', 'hash_algorithm', 'platform']
 
     ARG_DICT = {'format':         {'help': 'Archive format (e.g zip or tbz2)'},
-                'hash_algorithm': {'help': 'The algorithm for computing the archive hash (e.g. md5, blake2b)'},
+                'hash_algorithm': {'help': 'The algorithm for computing the archive hash (e.g. md5, blake2b, sha1, sha256)'},
                 'platform':       {'help': 'The name of the platform archive to be configured'}
                 }
 

--- a/autobuild/autobuild_tool_package.py
+++ b/autobuild/autobuild_tool_package.py
@@ -334,7 +334,7 @@ def _create_tarfile(tarfilename, format, build_directory, filelist, results: dic
     # (they use the --results-file option instead)
     print("wrote  %s" % tarfilename)
     results['autobuild_package_filename'] = tarfilename
-    _print_hash(tarfilename, results)
+    _calculate_hashes(tarfilename, results)
 
 
 def _create_zip_archive(archive_filename, build_directory, file_list, results: dict):
@@ -355,7 +355,7 @@ def _create_zip_archive(archive_filename, build_directory, file_list, results: d
     # (they use the --results-file option instead)
     print("wrote  %s" % archive_filename)
     results['autobuild_package_filename'] = archive_filename
-    _print_hash(archive_filename, results)
+    _calculate_hashes(archive_filename, results)
 
 
 def _add_file_to_zip_archive(zip_file, unnormalized_file, archive_filename, added_files):
@@ -379,16 +379,9 @@ def _add_file_to_zip_archive(zip_file, unnormalized_file, archive_filename, adde
         logger.info('added ' + file)
 
 
-def _print_hash(filename: str, results: dict):
-    md5 = common.compute_md5(filename)
-    blake2b = common.compute_blake2b(filename)
-
-    # printing unconditionally on stdout for backward compatibility
-    # the Linden Lab build scripts no longer rely on this
-    # (they use the --results-file option instead)
-    print("md5    %s" % md5)
-    results['autobuild_package_md5'] = md5
-    results['autobuild_package_blake2b'] = blake2b
-    # Not using logging, since this output should be produced unconditionally on stdout
-    # Downstream build tools utilize this output
+def _calculate_hashes(filename: str, results: dict):
+    results['autobuild_package_md5'] = common.compute_md5(filename)
+    results['autobuild_package_blake2b'] = common.compute_blake2b(filename)
+    results['autobuild_package_sha1'] = common.compute_sha1(filename)
+    results['autobuild_package_sha256'] = common.compute_sha256(filename)
 

--- a/autobuild/hash_algorithms.py
+++ b/autobuild/hash_algorithms.py
@@ -62,10 +62,20 @@ def verify_hash(hash_algorithm, pathname, hash):
 
 
 @hash_algorithm("md5")
-def _verify_md5(pathname, hash):
+def verify_md5(pathname, hash):
     return common.compute_md5(pathname) == hash
 
+
 @hash_algorithm("blake2b")
-def _verify_blake2b(pathname, hash):
+def verify_blake2b(pathname, hash):
     return common.compute_blake2b(pathname) == hash
 
+
+@hash_algorithm("sha1")
+def verify_sha1(pathname, hash):
+    return common.compute_sha1(pathname) == hash
+
+
+@hash_algorithm("sha256")
+def verify_sha256(pathname, hash):
+    return common.compute_sha256(pathname) == hash

--- a/tests/test_package.py
+++ b/tests/test_package.py
@@ -110,8 +110,10 @@ autobuild_package_platform="%s"
 autobuild_package_filename="%s"
 autobuild_package_md5="%s"
 autobuild_package_blake2b="%s"
+autobuild_package_sha1="%s"
+autobuild_package_sha256="%s"
 $''' % ('test1', re.escape(os.path.join(self.data_dir, "package-test", "autobuild-package.xml")),
-        "common", re.escape(self.tar_name), "[0-9a-f]{32}", "[0-9a-f]{128}")
+        "common", re.escape(self.tar_name), "[0-9a-f]{32}", "[0-9a-f]{128}", "[0-9a-f]{40}", "[0-9a-f]{64}")
         expected=re.compile(expected_results_regex, flags=re.MULTILINE)
         assert os.path.exists(results_output), "results file not found: %s" % results_output
         actual_results = open(results_output,'r').read()
@@ -133,6 +135,8 @@ $''' % ('test1', re.escape(os.path.join(self.data_dir, "package-test", "autobuil
             self.assertEqual(results["autobuild_package_filename"], self.tar_name)
             self.assertEqual(len(results["autobuild_package_md5"]), 32)
             self.assertEqual(len(results["autobuild_package_blake2b"]), 128)
+            self.assertEqual(len(results["autobuild_package_sha1"]), 40)
+            self.assertEqual(len(results["autobuild_package_sha256"]), 64)
 
     def test_package_other_version(self):
         # read the existing metadata file and update stored package version


### PR DESCRIPTION
It is relatively common to distribute archives with a majority of common hash types. Let's include sha1 and sha256 in addition to the existing algorithms.

- Added sha1 package hash
- Added sha256 package hash
- Perform streamed hashing of packages to improve performance with larger archives