### PR TITLE
Add support for overriding AUTOBUILD_CPU_COUNT from environment

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ For more information, see [Autobuild's wiki page][wiki].
 | AUTOBUILD_BUILD_ID | - | Build identifier |
 | AUTOBUILD_CONFIGURATION | - | Target build configuration |
 | AUTOBUILD_CONFIG_FILE | autobuild.xml | Autobuild configuration filename |
+| AUTOBUILD_CPU_COUNT | - | Build system cpu core count |
 | AUTOBUILD_GITHUB_TOKEN | - | GitHub HTTP authorization token to use during package download |
 | AUTOBUILD_GITLAB_TOKEN | - | GitLab HTTP authorization token to use during package download |
 | AUTOBUILD_INSTALLABLE_CACHE | - | Location of local download cache |

--- a/autobuild/common.py
+++ b/autobuild/common.py
@@ -164,7 +164,7 @@ def establish_platform(specified_platform=None, addrsize=DEFAULT_ADDRSIZE):
     os.environ['AUTOBUILD_ADDRSIZE'] = str(addrsize) # for spawned commands
     os.environ['AUTOBUILD_PLATFORM'] = Platform # for spawned commands
     os.environ['AUTOBUILD_PLATFORM_OVERRIDE'] = Platform # for recursive invocations
-    os.environ['AUTOBUILD_CPU_COUNT'] = str(multiprocessing.cpu_count())
+    os.environ['AUTOBUILD_CPU_COUNT'] = os.environ.get('AUTOBUILD_CPU_COUNT', str(multiprocessing.cpu_count()))
 
     logger.debug("Specified platform %s address-size %d: result %s" \
                  % (specified_platform, specified_addrsize, Platform))


### PR DESCRIPTION
This would add support for the user to export AUTOBUILD_CPU_COUNT themselves for resource constrained situations to limit number of compilation threads potentially selected by build scripts