### PR TITLE
Add support for svg and jpeg output to autobuild graph

### DIFF
--- a/autobuild/autobuild_tool_graph.py
+++ b/autobuild/autobuild_tool_graph.py
@@ -228,12 +228,7 @@ class AutobuildTool(autobuild_base.AutobuildBase):
             root.set_shape('octagon')
 
             if args.dot_file:
-                try:
-                    dot_file=open(args.dot_file,'w')
-                except IOError as err:
-                    raise GraphError("Unable to open dot file %s: %s" % (args.dot_file, err))
-                dot_file.write(graph.to_string())
-                dot_file.close()
+                graph.write_raw(args.dot_file)
 
             if args.display or args.graph_file:
                 if args.graph_file:
@@ -243,7 +238,12 @@ class AutobuildTool(autobuild_base.AutobuildBase):
                                                 metadata['package_description']['name'] + "_graph_"
                                                 + args.graph_type + '.png')
                 logger.info("writing %s" % graph_file)
-                graph.write_png(graph_file, prog=args.graph_type)
+                if graph_file.endswith('.svg'):
+                    graph.write_svg(graph_file, prog=args.graph_type)
+                elif graph_file.endswith('.jpeg'):
+                    graph.write_jpeg(graph_file, prog=args.graph_type)
+                else:
+                    graph.write_png(graph_file, prog=args.graph_type)
                 if args.display and not args.graph_file:
                     webbrowser.open('file:'+graph_file)
             else:

--- a/tests/test_graph.py
+++ b/tests/test_graph.py
@@ -69,16 +69,46 @@ class TestGraph(BaseTest):
         assert_found_in("bingo \\[", output_lines)
         assert_in("bingo -> bongo;", output_lines)
 
-    def test_output(self):
+    def test_dot_output(self):
         self.tmp_dir = tempfile.mkdtemp()
         try:
-            self.options.graph_file = os.path.join(self.tmp_dir, "graph.png")
             self.options.dot_file = os.path.join(self.tmp_dir, "graph.dot")
             self.options.source_file = os.path.join(self.this_dir, "data", "bongo-0.1-common-111.tar.bz2")
             graph.AutobuildTool().run(self.options)
-            # for now, settle for detecting that the png file was created
-            assert os.path.exists(self.options.graph_file)
             assert os.path.exists(self.options.dot_file)
+
+        finally:
+            clean_dir(self.tmp_dir)
+
+    def test_png_output(self):
+        self.tmp_dir = tempfile.mkdtemp()
+        try:
+            self.options.graph_file = os.path.join(self.tmp_dir, "graph.png")
+            self.options.source_file = os.path.join(self.this_dir, "data", "bongo-0.1-common-111.tar.bz2")
+            graph.AutobuildTool().run(self.options)
+            assert os.path.exists(self.options.graph_file)
+
+        finally:
+            clean_dir(self.tmp_dir)
+
+    def test_jpeg_output(self):
+        self.tmp_dir = tempfile.mkdtemp()
+        try:
+            self.options.graph_file = os.path.join(self.tmp_dir, "graph.jpeg")
+            self.options.source_file = os.path.join(self.this_dir, "data", "bongo-0.1-common-111.tar.bz2")
+            graph.AutobuildTool().run(self.options)
+            assert os.path.exists(self.options.graph_file)
+
+        finally:
+            clean_dir(self.tmp_dir)
+
+    def test_svg_output(self):
+        self.tmp_dir = tempfile.mkdtemp()
+        try:
+            self.options.graph_file = os.path.join(self.tmp_dir, "graph.svg")
+            self.options.source_file = os.path.join(self.this_dir, "data", "bongo-0.1-common-111.tar.bz2")
+            graph.AutobuildTool().run(self.options)
+            assert os.path.exists(self.options.graph_file)
 
         finally:
             clean_dir(self.tmp_dir)


### PR DESCRIPTION
This adds support for outputting jpeg or svg images from autobuild graph along with additional tests covering creation of those images