### PR TITLE
Provide a suggested Visual Studio C++ SDK version

### DIFF
--- a/autobuild/autobuild_tool_source_environment.py
+++ b/autobuild/autobuild_tool_source_environment.py
@@ -21,6 +21,14 @@ class SourceEnvError(common.AutobuildError):
 _VSxxxCOMNTOOLS_re = re.compile(r"VS(.*)COMNTOOLS$")
 _VSxxxCOMNTOOLS_st = "VS%sCOMNTOOLS"
 
+# Map of Visual Studio version to respective default C++ SDK toolset version
+_VSTOOLSETS = {
+    "140": "v140", # 2015
+    "150": "v141", # 2017
+    "160": "v142", # 2019
+    "170": "v143", # 2022
+}
+
 # From VS 2017 on, we have to look for vswhere.exe at this canonical path to
 # discover where the Visual Studio install is.
 # https://stackoverflow.com/a/44323312
@@ -736,6 +744,12 @@ def internal_source_environment(configurations, varsfile):
                 AUTOBUILD_WIN_CMAKE_GEN += " Win64"
             # cmake -G "$AUTOBUILD_WIN_CMAKE_GEN"
             exports["AUTOBUILD_WIN_CMAKE_GEN"] = AUTOBUILD_WIN_CMAKE_GEN
+
+            try:
+                # Provide a suggested C++ SDK version for build scripts to use
+                exports["AUTOBUILD_WIN_VSTOOLSET"] = os.environ.get("AUTOBUILD_WIN_VSTOOLSET", _VSTOOLSETS[vsver])
+            except KeyError:
+                logger.warning(f"Unable to determine a suggested AUTOBUILD_WIN_VSTOOLSET for vsver {vsver}")
 
             # load vsvars32.bat variables
             vsvars = load_vsvars(vsver)

--- a/tests/basetest.py
+++ b/tests/basetest.py
@@ -299,4 +299,5 @@ def git_repo():
 
 
 needs_git = pytest.mark.skipif(not has_cmd("git"), reason="git not present on system")
-needs_nix = pytest.mark.skipif(not has_cmd("which", "bash"), reason="not running in a unix-like environment")
+needs_nix = pytest.mark.skipif(not has_cmd("which", "bash"), reason="needs unix-like environment")
+needs_cygwin = pytest.mark.skipif(not has_cmd("cygpath", "-h"), reason="needs windows environment")

--- a/tests/test_source_environment.py
+++ b/tests/test_source_environment.py
@@ -4,7 +4,6 @@ import shutil
 import subprocess
 import sys
 import tempfile
-import unittest
 from ast import literal_eval
 from pprint import pformat
 
@@ -319,5 +318,16 @@ replace_switch def xyz $switches""").split()),
         assert_found_assignment("LL_BUILD", "darwin release", stdout)
         assert_found_assignment("SOMETHING_ELSE", "something else", stdout)
 
-if __name__ == '__main__':
-    unittest.main()
+    @needs_cygwin
+    def test_vstoolset_set(self):
+        with capture_stdout_buffer() as outbuf, envvar("AUTOBUILD_VSVER", "170"):
+            self.autobuild_call(self.find_data("empty"), "RelWithDebInfo")
+        stdout = outbuf.getvalue().decode("utf-8")
+        self.assertIn(f"export AUTOBUILD_WIN_VSTOOLSET='v143'", stdout)
+
+    @needs_cygwin
+    def test_vstoolset_not_set_if_vsver_unrecognized(self):
+        with capture_stdout_buffer() as outbuf, envvar("AUTOBUILD_VSVER", "171"):
+            self.autobuild_call(self.find_data("empty"), "RelWithDebInfo")
+        stdout = outbuf.getvalue().decode("utf-8")
+        self.assertNotIn(f"export AUTOBUILD_WIN_VSTOOLSET=", stdout)


### PR DESCRIPTION
This changeset provides a suggested Visual Studio C++ SDK toolset version to build scripts in the form of an `AUTOBUILD_WIN_VSTOOLSET` environment variable. This can be handy when working with vendor sources such as [icu](https://github.com/unicode-org/icu/), which have hard-coded Visual Studio project files.