### PR TITLE
Dedupe windows PATH during source_environment

### DIFF
--- a/tests/test_source_environment.py
+++ b/tests/test_source_environment.py
@@ -320,14 +320,12 @@ replace_switch def xyz $switches""").split()),
 
     @needs_cygwin
     def test_vstoolset_set(self):
-        with capture_stdout_buffer() as outbuf, envvar("AUTOBUILD_VSVER", "170"):
-            self.autobuild_call(self.find_data("empty"), "RelWithDebInfo")
-        stdout = outbuf.getvalue().decode("utf-8")
-        self.assertIn(f"export AUTOBUILD_WIN_VSTOOLSET='v143'", stdout)
+        with envvar("AUTOBUILD_VSVER", "170"):
+            vars = self.read_variables(self.find_data("empty"))
+        self.assertEqual(vars["AUTOBUILD_WIN_VSTOOLSET"], "v143")
 
     @needs_cygwin
     def test_vstoolset_not_set_if_vsver_unrecognized(self):
-        with capture_stdout_buffer() as outbuf, envvar("AUTOBUILD_VSVER", "171"):
-            self.autobuild_call(self.find_data("empty"), "RelWithDebInfo")
-        stdout = outbuf.getvalue().decode("utf-8")
-        self.assertNotIn(f"export AUTOBUILD_WIN_VSTOOLSET=", stdout)
+        with envvar("AUTOBUILD_VSVER", "171"):
+            vars = self.read_variables(self.find_data("empty"))
+        self.assertTrue("AUTOBUILD_WIN_VSTOOLSET" not in vars)


### PR DESCRIPTION
Many 3p package buildscripts contain a [gnarly bash function](https://github.com/secondlife/3p-openssl/blob/9ec07a269678de98bcfbbb75537225221cdc3362/build-cmd.sh#L104-L123) that deduplicates the PATH on windows in order to avoid truncation when the variable grows to long. This exceptionally long PATH is caused by Autobuild adding many duplicate entries during load_vsvars as it essentially performs PATH="$PATH:$PATH"

To avoid this, this changeset removes any entries from the load_vsvars provided value if they already exist in the system PATH. This should result in a clean addition of only new vcvars32.bat directories.