### PR TITLE
Improved package install speed

### DIFF
--- a/autobuild/autobuild_tool_configure.py
+++ b/autobuild/autobuild_tool_configure.py
@@ -83,7 +83,7 @@ class AutobuildTool(autobuild_base.AutobuildBase):
             os.chdir(current_directory)
 
 
-def _configure_a_configuration(config, build_configuration, extra_arguments, dry_run=False,
+def _configure_a_configuration(config: configfile.BuildConfigurationDescription, build_configuration, extra_arguments, dry_run=False,
                                environment=None):
     try:
         common_build_configuration = \

--- a/autobuild/autobuild_tool_graph.py
+++ b/autobuild/autobuild_tool_graph.py
@@ -13,7 +13,7 @@ from io import StringIO
 from typing import NamedTuple
 
 from autobuild import autobuild_base, common, configfile
-from autobuild.autobuild_tool_install import extract_metadata_from_package
+from autobuild.autobuild_tool_install import get_metadata_from_package
 
 logger = logging.getLogger('autobuild.graph')
 
@@ -130,11 +130,9 @@ class AutobuildTool(autobuild_base.AutobuildBase):
         else:
             # assume that the file is a package archive and try to get metadata from it
             logger.info("searching for metadata in autobuild package file %s" % args.source_file)
-            metadata_stream = extract_metadata_from_package(args.source_file, configfile.PACKAGE_METADATA_FILE)
-            if metadata_stream is not None:
-                metadata = configfile.MetadataDescription(stream=metadata_stream)
-                if not metadata:
-                    raise GraphError("No metadata found in archive '%s'" % args.file)
+            metadata = get_metadata_from_package(args.source_file)
+            if not metadata:
+                raise GraphError("No metadata found in archive '%s'" % args.source_file)
 
         if not metadata:
             raise GraphError("No metadata found")

--- a/tests/test_install.py
+++ b/tests/test_install.py
@@ -155,6 +155,7 @@ def setup_module(module):
                      local_archives=[],
                      addrsize=32,
                      package=[],
+                     skip_source_environment=False,
                      ):
             # Take all constructor params and assign as object attributes.
             params = locals().copy()


### PR DESCRIPTION
This changeset makes `autobuild install` notably faster at extracting package contents. It accomplishes this by eliminating redundant enumeration of archive contents and eagerly extracting archive content when inspecting metadata.

3p-boost (cached installables)
```
Before 4.610s
After  2.655s
```

viewer (cached installables)
```
Before 4m3.381s 
After  2m1.321s
```

Other changes

In addition to archive unpacking improvements, this changeset adds a new `--skip-source-environment` argument which may be passed to `autobuild install`. This is useful with codebases like Second Life's viewer, where `autobuild install` is called many times by an external script (cmake.)