### PR TITLE
Fix autobuild install failing on private sources

### DIFF
--- a/autobuild/autobuild_tool_install.py
+++ b/autobuild/autobuild_tool_install.py
@@ -380,7 +380,7 @@ def _install_binary(configured_name, platform, package, config_file, install_dir
 
     # get the package file in the cache, downloading if needed, and verify the hash
     # (raises InstallError on failure, so no check is needed)
-    cachefile = get_package_file(package_name, archive.url, hash_algorithm=(archive.hash_algorithm or 'md5'), expected_hash=archive.hash)
+    cachefile = get_package_file(package_name, archive.url, hash_algorithm=(archive.hash_algorithm or 'md5'), expected_hash=archive.hash, creds=(archive.creds or None))
     if cachefile is None:
         raise InstallError("Failed to download package '%s' from '%s'" % (package_name, archive.url))
 

--- a/autobuild/configfile.py
+++ b/autobuild/configfile.py
@@ -681,6 +681,7 @@ class ArchiveDescription(common.Serialized):
     # Implementations for various values of hash_algorithm should be found in
     # hash_algorithms.py.
     def __init__(self, dictionary=None):
+        self.creds = None
         self.format = None
         self.hash = None
         self.hash_algorithm = None

--- a/autobuild/update.py
+++ b/autobuild/update.py
@@ -190,7 +190,7 @@ class _Update_1_1(object):
 
     @staticmethod
     def ArchiveDescription():
-        return {'format': None, 'hash': None, 'hash_algorithm': None, 'url': None}
+        return {'creds': None, 'format': None, 'hash': None, 'hash_algorithm': None, 'url': None}
 
     @staticmethod
     def BuildConfigurationDescription():


### PR DESCRIPTION
autobuild install from private sources such as gitlab fails to authorize due to creds not being passed.