### PR TITLE
Fix github private package downloads

### DIFF
--- a/autobuild/autobuild_tool_install.py
+++ b/autobuild/autobuild_tool_install.py
@@ -202,6 +202,10 @@ def download_package(package_url: str, timeout=120, creds=None, package_name="")
             token_var = CREDENTIAL_ENVVARS[creds]
         except KeyError:
             logger.warning(f"Unrecognized creds={creds} value")
+        
+        if creds == "github":
+            # Request octet-stream if creds=github, or else we'll get a JSON response back
+            req.add_unredirected_header("Accept", "application/octet-stream")
 
         token = os.environ.get(token_var)
         if token:

--- a/tests/test_install.py
+++ b/tests/test_install.py
@@ -762,6 +762,7 @@ class TestDownloadPackage(unittest.TestCase):
             mock_urlopen.assert_called()
             got_req = mock_urlopen.mock_calls[0].args[0]
             self.assertEqual(got_req.unredirected_hdrs["Authorization"], "Bearer token-123")
+            self.assertEqual(got_req.unredirected_hdrs["Accept"], "application/octet-stream")
 
     @patch("urllib.request.urlopen")
     def test_download_gitlab(self, mock_urlopen: MagicMock):


### PR DESCRIPTION
Github private repository asset URLs will return an API response in JSON by default. Set the Accept header to `application/octet-stream` to download an actual file.

This PR compliments https://github.com/secondlife/action-autobuild-release/pull/14, which switches the URL format used when presenting release asset URLs for private Github repositories.