### PR TITLE
Only upload code coverage on linux

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -40,6 +40,7 @@ jobs:
 
       - name: Upload coverage
         uses: codecov/codecov-action@v3
+        if: matrix.os == 'ubuntu-latest'
         with:
           env_vars: OS
 


### PR DESCRIPTION
Limit codecov coverage upload to runs on ubuntu-latest so that it is not confused by coverage differences between platforms.