### PR TITLE
Fix union hint on < py310

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -12,6 +12,14 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
+        python-version: ["3.11"]
+        include:
+          - os: ubuntu-latest
+            python-version: "3.8"
+          - os: ubuntu-latest
+            python-version: "3.9"
+          - os: ubuntu-latest
+            python-version: "3.10"
     env:
       OS: ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
@@ -22,7 +30,7 @@ jobs:
 
       - uses: actions/setup-python@v4
         with:
-          python-version: 3.x
+          python-version: ${{ matrix.python-version }}
 
       - name: Install python dependencies
         run: pip install .[dev,build]

--- a/autobuild/archive_utils.py
+++ b/autobuild/archive_utils.py
@@ -1,6 +1,7 @@
 import multiprocessing
 import tarfile
 import zipfile
+from typing import Union
 
 class ArchiveType:
     GZ = "gz"
@@ -51,7 +52,7 @@ def detect_archive_type(filename: str):
     return _archive_type_from_signature(filename)
 
 
-def open_archive(filename: str) -> tarfile.TarFile | zipfile.ZipFile:
+def open_archive(filename: str) -> Union[tarfile.TarFile, zipfile.ZipFile]:
     f_type = detect_archive_type(filename)
 
     if f_type == ArchiveType.ZST:


### PR DESCRIPTION
Replace 310 | type sugar with Union to fix TypeError in older python versions.

```
 TypeError: unsupported operand type(s) for |: 'type' and 'type'
```