### PR TITLE
Fix py37 support

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -15,6 +15,8 @@ jobs:
         python-version: ["3.11"]
         include:
           - os: ubuntu-latest
+            python-version: "3.7"
+          - os: ubuntu-latest
             python-version: "3.8"
           - os: ubuntu-latest
             python-version: "3.9"

--- a/autobuild/common.py
+++ b/autobuild/common.py
@@ -326,12 +326,12 @@ def compute_hash(path: str, hash: Callable[[], hashlib._Hash]):
     Compute a hash for a file effeciently by streaming it into the hash algorithm
     """
     h = hash()
-    b = bytearray(128*1024)
-    mv = memoryview(b)
     try:
         with open(path, 'rb') as f:
-            while n := f.readinto(mv):
-                h.update(mv[:n])
+            chunk = f.read(8192)
+            while chunk:
+                h.update(chunk)
+                chunk = f.read(8192)
             return h.hexdigest()
     except IOError as err:
         raise AutobuildError(f"Can't compute {h.name} for {path}: {err}")

--- a/tests/test_install.py
+++ b/tests/test_install.py
@@ -751,7 +751,8 @@ class TestDownloadPackage(unittest.TestCase):
         with envvar("AUTOBUILD_GITHUB_TOKEN", None):
             autobuild_tool_install.download_package("https://example.org/foo.tar.bz2")
             mock_urlopen.assert_called()
-            got_req = mock_urlopen.mock_calls[0].args[0]
+            _, args, _ = mock_urlopen.mock_calls[0]
+            got_req = args[0]
             self.assertIsNone(got_req.unredirected_hdrs.get("Authorization"))
 
     @patch("urllib.request.urlopen")
@@ -760,7 +761,8 @@ class TestDownloadPackage(unittest.TestCase):
         with envvar("AUTOBUILD_GITHUB_TOKEN", "token-123"):
             autobuild_tool_install.download_package("https://example.org/foo.tar.bz2", creds="github")
             mock_urlopen.assert_called()
-            got_req = mock_urlopen.mock_calls[0].args[0]
+            _, args, _ = mock_urlopen.mock_calls[0]
+            got_req = args[0]
             self.assertEqual(got_req.unredirected_hdrs["Authorization"], "Bearer token-123")
             self.assertEqual(got_req.unredirected_hdrs["Accept"], "application/octet-stream")
 
@@ -770,7 +772,8 @@ class TestDownloadPackage(unittest.TestCase):
         with envvar("AUTOBUILD_GITLAB_TOKEN", "token-123"):
             autobuild_tool_install.download_package("https://example.org/foo.tar.bz2", creds="gitlab")
             mock_urlopen.assert_called()
-            got_req = mock_urlopen.mock_calls[0].args[0]
+            _, args, _ = mock_urlopen.mock_calls[0]
+            got_req = args[0]
             self.assertEqual(got_req.unredirected_hdrs["Authorization"], "Bearer token-123")
 
     @patch("urllib.request.urlopen")


### PR DESCRIPTION
Remove a few 3.8+ changes so that autobuild continues to function on 3.7. This is needed as long as LL is using Debian Buster.