### PR TITLE
Automatically bump major version

### DIFF
--- a/.github/workflows/bump-major.yaml
+++ b/.github/workflows/bump-major.yaml
@@ -1,0 +1,9 @@
+name: Bump major version 
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  Tag:
+    uses: secondlife/update-major-tag-workflow/.github/workflows/update-major-tag.yaml@v1


### PR DESCRIPTION
Use secondlife/update-major-tag-workflow to automatically bump the major version tag (v3, etc.) when a new release is published.