### PR TITLE
Revert "README.md 64bit builds are a better default / example"

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ For more information, see [Autobuild's wiki page][wiki].
 
 | Name | Default | Description |
 |-|-|-|
-| AUTOBUILD_ADDRSIZE | 64 | Target address size |
+| AUTOBUILD_ADDRSIZE | 32 | Target address size |
 | AUTOBUILD_BUILD_ID | - | Build identifier |
 | AUTOBUILD_CONFIGURATION | - | Target build configuration |
 | AUTOBUILD_CONFIG_FILE | autobuild.xml | Autobuild configuration filename |

--- a/autobuild/common.py
+++ b/autobuild/common.py
@@ -39,7 +39,7 @@ PLATFORM_LINUX     = 'linux'
 PLATFORM_LINUX64   = 'linux64'
 PLATFORM_COMMON    = 'common'
 
-DEFAULT_ADDRSIZE = 64
+DEFAULT_ADDRSIZE = 32
 
 # Similarly, if we have an explicit platform in the environment, keep it. We
 # used to query os.environ in establish_platform(), instead of up here. The


### PR DESCRIPTION
Reverts secondlife/autobuild#29 - this will need to be a breaking change.