### PR TITLE
Update upload/download artifact to v4

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -54,9 +54,10 @@ jobs:
         with:
           env_vars: OS
 
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
+        if: matrix.os == 'ubuntu-latest' && matrix.python-version == '3.11'
         with:
-          name: dist-${{ matrix.os }}
+          name: dist
           path: dist
 
   publish:
@@ -67,9 +68,9 @@ jobs:
       id-token: write
     if: github.event_name != 'pull_request'
     steps:
-      - uses: actions/download-artifact@v3
+      - uses: actions/download-artifact@v4
         with:
-          name: dist-ubuntu-latest
+          name: dist
           path: dist
 
       - name: Test Publish package


### PR DESCRIPTION
Bump actions/upload-artifact and actions/download-artifact to v4. Breaking changes described [here](https://github.com/actions/upload-artifact?tab=readme-ov-file#breaking-changes).