### PR TITLE
Hash comparisons should be case insensitive

### DIFF
--- a/autobuild/hash_algorithms.py
+++ b/autobuild/hash_algorithms.py
@@ -56,6 +56,9 @@ def verify_hash(hash_algorithm, pathname, hash):
         raise AutobuildError("Unsupported hash type %s for %s" %
                              (hash_algorithm, pathname))
 
+    # The final comparison should be case insensitive
+    hash = hash.lower()
+
     # Apparently we do have a function to support this hash_algorithm. Call
     # it.
     return function(pathname, hash)


### PR DESCRIPTION
`Get-FileHash -Algorithm MD5 archive_name.tar.bz2` generates an md5 hash with all caps, and the case sensitive compare tripped me up in development. Hopefully this change will be a quality of life improvement for future users.

All of the supported hash's are inherently case insensitive, so this will not affect functionality.