### PR TITLE
Remove automatic major version bump

### DIFF
--- a/.github/workflows/bump-major.yaml
+++ b/.github/workflows/bump-major.yaml
@@ -1,9 +1,0 @@
-name: Bump major version 
-
-on:
-  release:
-    types: [published]
-
-jobs:
-  Tag:
-    uses: secondlife/update-major-tag-workflow/.github/workflows/update-major-tag.yaml@v1


### PR DESCRIPTION
Remove workflows/bump-major.yaml to avoid setuptools_scm confusion.

Without this, publications to PyPI can end up publishing the major version instead of the expected full semver.