### PR TITLE
Require llsd>=1.2.4, indent fix

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -30,7 +30,7 @@ setuptools.setup(
         'Programming Language :: Python :: 3',
         'Topic :: Software Development :: Libraries :: Python Modules',
     ],
-    install_requires=['llsd', 'pydot', 'pyzstd'],
+    install_requires=['llsd>=1.2.4', 'pydot', 'pyzstd'],
     extras_require={
         'dev': ['pytest', 'pytest-cov'],
         'build': ['build', 'setuptools_scm'],


### PR DESCRIPTION
Fix autobuild.xml indentation churn by requiring llsd 1.2.4.