### PR TITLE
Allow installables edit cmd to remove attributes

### DIFF
--- a/autobuild/autobuild_tool_installables.py
+++ b/autobuild/autobuild_tool_installables.py
@@ -17,7 +17,7 @@ logger = logging.getLogger('autobuild.installables')
 
 
 # Match key=value arguments.
-_key_value_regexp = re.compile(r'(\w+)\s*=\s*(\S+)')
+_key_value_regexp = re.compile(r'(\w+)\s*=\s*(\S+)?')
 
 
 class InstallablesError(common.AutobuildError):
@@ -219,9 +219,12 @@ def edit(config, args_name, args_archive, arguments):
         installed_package_description.platforms[platform_name] = platform_description.copy()
 
     for element in _ARCHIVE_ATTRIBUTES:
-        if element in metadata.archive \
-          and metadata.archive[element] is not None:
-            installed_package_description.platforms[platform_name].archive[element] = metadata.archive[element]
+        if element in metadata.archive:
+            if metadata.archive[element] is None:
+                # Allow installables edit to remove archive elements, such as creds, by passing "creds="
+                del installed_package_description.platforms[platform_name].archive[element]
+            else:
+                installed_package_description.platforms[platform_name].archive[element] = metadata.archive[element]
 
 
 

--- a/tests/test_installables.py
+++ b/tests/test_installables.py
@@ -17,7 +17,7 @@ class TestInstallables(BaseTest, AutobuildBaselineCompare):
     def test_add_edit_remove(self):
         local_archive=os.path.join(self.datadir,'bogus-0.1-common-111.tar.bz2')
         data = ('license=tut', 'license_file=LICENSES/bogus.txt', 'platform=darwin',
-            'url='+local_archive)
+            'url='+local_archive, 'creds=github')
         installables.add(self.config, 'bogus', None, data)
         self.assertEqual(len(self.config.installables), 1)
         package_description = self.config.installables['bogus']
@@ -27,10 +27,13 @@ class TestInstallables(BaseTest, AutobuildBaselineCompare):
         platform_description = package_description.platforms['darwin']
         assert platform_description.archive is not None
         assert platform_description.archive.url.endswith(local_archive)
-        edit_data = ('license=Apache', 'platform=darwin', 'hash_algorithm=sha-1')
+        self.assertEqual(platform_description.archive.creds, 'github')
+        edit_data = ('license=Apache', 'platform=darwin', 'hash_algorithm=sha-1', 'creds=')
         installables.edit(self.config, 'bogus', None, edit_data)
         self.assertEqual(package_description.license, 'Apache')
         self.assertEqual(platform_description.archive.hash_algorithm, 'sha-1')
+        platform_description = package_description.platforms['darwin']
+        self.assertNotIn('creds', platform_description.archive)
         installables.remove(self.config, 'bogus')
         self.assertEqual(len(self.config.installables), 0)
 


### PR DESCRIPTION
Provide a way for users to remove elements of package metadata through `installables edit` by passing just the key with no value, ex. `creds=`.

Fixes https://github.com/secondlife/autobuild/issues/46