### PR TITLE
Better support non-semver SCM versions

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,13 +1,13 @@
 repos:
 - repo: https://github.com/pre-commit/pre-commit-hooks
-  rev: v4.3.0
+  rev: v4.6.0
   hooks:
     - id: check-ast
     - id: check-yaml
     - id: mixed-line-ending
     - id: trailing-whitespace
 - repo: https://github.com/pycqa/isort
-  rev: 5.10.1
+  rev: 5.13.2
   hooks:
     - id: isort
       args: [--line-length=120]

--- a/tests/basetest.py
+++ b/tests/basetest.py
@@ -262,7 +262,7 @@ def envvar(key: str, val: str | None):
 
 
 @contextmanager
-def git_repo():
+def git_repo(initial_tag="v1.0.0"):
     """
     Initialize a new git repository in a temporary directory, yield its path, clean after context exit.
 
@@ -290,7 +290,7 @@ def git_repo():
             cmd("git", "remote", "add", "origin", "https://example.com/foo.git")
             cmd("git", "add", "-A")
             cmd("git", "commit", "-m", "Initial")
-            cmd("git", "tag", "v1.0.0")
+            cmd("git", "tag", initial_tag)
             yield root
         finally:
             # Make sure to chdir out of temp_dir before closing it, otherwise windows

--- a/tests/test_scm_git.py
+++ b/tests/test_scm_git.py
@@ -10,6 +10,22 @@ from tests.basetest import chdir, git_repo, needs_git
 
 
 @needs_git
+class InvalidSemverTests(TestCase):
+    def test_invalid_semver(self):
+        with git_repo("v1.1.1q") as repo:
+            version = get_version(repo)
+            self.assertEqual(version, "1.1.1q")
+
+    def test_dirty_invalid_semver(self):
+        with git_repo("v1.1.1q") as repo:
+            with open(os.path.join(repo, "file"), "w") as f:
+                f.write("+1")
+            cmd("git", "add", "file")
+            version = get_version(repo)
+            self.assertRegex(version, fr"^1\.1\.1q\-dev0\.g[a-z0-9]{{7}}.d{date()}$")
+
+
+@needs_git
 class GitTests(TestCase):
     repo: str
 


### PR DESCRIPTION
Fall back to using the last git tag starting with `v\d.+` if no valid semver is found. This is useful when using vendored tag versions such as libcurl's `v1.1.1q`.