### PR TITLE
Fix CI/CD: remove python 3.7 support

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -15,8 +15,6 @@ jobs:
         python-version: ["3.11"]
         include:
           - os: ubuntu-latest
-            python-version: "3.7"
-          - os: ubuntu-latest
             python-version: "3.8"
           - os: ubuntu-latest
             python-version: "3.9"


### PR DESCRIPTION
Drop support for python 3.7, which is no longer provided by Github actions.